### PR TITLE
Add rate limiting and caching

### DIFF
--- a/config/api.yaml
+++ b/config/api.yaml
@@ -4,6 +4,8 @@ apis:
   osrm:
     base_url: "http://localhost:5000"
     timeout: 30
+    requests_per_second: 10
+    cache: true
 
   fbi_crime:
     base_url: "https://api.usa.gov/crime/fbi/cde/"

--- a/src/apis/osrm.py
+++ b/src/apis/osrm.py
@@ -3,13 +3,17 @@ import logging
 from typing import Dict, Any, Optional
 
 import requests
+from .rate_limiter import RateLimiter, APIHandler
 
 class OSRMClient:
     """Simple OSRM API client with offline fallback."""
 
-    def __init__(self, base_url: str = "http://localhost:5000", timeout: int = 30):
+    def __init__(self, base_url: str = "http://localhost:5000", timeout: int = 30,
+                 requests_per_second: int = 10, api_handler: Optional[APIHandler] = None):
         self.base_url = base_url.rstrip('/')
         self.timeout = timeout
+        self.rate_limiter = RateLimiter(requests_per_second=requests_per_second)
+        self.api_handler = api_handler or APIHandler()
         self.logger = logging.getLogger(__name__)
 
     def route(self, origin: Dict[str, float], destination: Dict[str, float], profile: str = "driving") -> Dict[str, Any]:
@@ -19,7 +23,8 @@ class OSRMClient:
         """
         url = f"{self.base_url}/route/v1/{profile}/{origin['lon']},{origin['lat']};{destination['lon']},{destination['lat']}?overview=false"
         try:
-            resp = requests.get(url, timeout=self.timeout)
+            self.rate_limiter.wait_if_needed()
+            resp = self.api_handler.call_with_retry(lambda: requests.get(url, timeout=self.timeout))
             resp.raise_for_status()
             data = resp.json()
             if data.get('routes'):

--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -290,6 +290,17 @@ class ConfigParser:
         if not isinstance(osrm_cfg['base_url'], str) or osrm_cfg['base_url'].strip() == '':
             raise ConfigValidationError("Invalid OSRM base_url")
 
+        if 'timeout' in osrm_cfg and (not isinstance(osrm_cfg['timeout'], int) or osrm_cfg['timeout'] <= 0):
+            raise ConfigValidationError("OSRM timeout must be positive integer")
+
+        if 'requests_per_second' in osrm_cfg:
+            rps = osrm_cfg['requests_per_second']
+            if not isinstance(rps, int) or rps <= 0:
+                raise ConfigValidationError("requests_per_second must be positive integer")
+
+        if 'cache' in osrm_cfg and not isinstance(osrm_cfg['cache'], bool):
+            raise ConfigValidationError("OSRM cache must be boolean")
+
         if 'fbi_crime' not in apis:
             raise ConfigValidationError("API config missing fbi_crime section")
 

--- a/tests/unit/test_cache_rate_limit.py
+++ b/tests/unit/test_cache_rate_limit.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from src.analyzer import LocationAnalyzer
+from src.core.grid_generator import AnalysisGrid
+from src.config_parser import ConfigParser
+from src.apis.cache import save_cached_route
+from src.apis.osrm import OSRMClient
+from src.apis.rate_limiter import APIHandler
+
+
+def load_config():
+    parser = ConfigParser()
+    config_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'config'))
+    cfg = parser.load_config(config_dir)
+    parser.validate_config(cfg)
+    return cfg
+
+
+def test_cached_route_used(tmp_path):
+    cfg = load_config()
+    analyzer = LocationAnalyzer(cfg)
+    analyzer.grid = AnalysisGrid(40.0, -75.0, radius_miles=0.1, grid_size_miles=0.1)
+    analyzer.schedules = [{
+        'destination': 'Test Dest',
+        'lat': 40.1,
+        'lon': -75.1,
+        'departure_time': '09:00',
+        'day': 'Mon',
+        'category': 'work',
+        'frequency': 'weekly',
+        'annual_occurrences': 52
+    }]
+    point = analyzer.grid.grid_df.iloc[0]
+    route = {'distance_miles': 1.0, 'duration_seconds': 100, 'status': 'OK'}
+    save_cached_route(point['lat'], point['lon'], 'Test Dest', '09:00', 'Mon', route)
+    result = analyzer._calculate_routes()
+    assert result['cache_hits'] == 1
+    assert result['total_api_calls'] == 0
+
+
+def test_rate_limiter_delay():
+    client = OSRMClient(base_url="http://invalid.local", requests_per_second=2, api_handler=APIHandler(retry_count=1))
+    origin = {'lat': 40.0, 'lon': -75.0}
+    dest = {'lat': 40.1, 'lon': -75.1}
+    start = time.time()
+    client.route(origin, dest)
+    client.route(origin, dest)
+    elapsed = time.time() - start
+    assert elapsed >= 0.5


### PR DESCRIPTION
## Summary
- support requests_per_second and cache options in API config
- validate these options in the config parser
- rate limit OSRMClient requests and retry with APIHandler
- cache OSRM routes in LocationAnalyzer
- test caching and rate limiting behaviors

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c2ff81aac8322aff23a53a51d9823