### PR TITLE
Load optional API secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ outputs
 node_modules
 package-lock.json
 package.json
+config/api_secrets.yaml

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Configuration is split into several YAML files:
 - **api.yaml** – OSRM server settings and rate limits
 - **weights.yaml** – scoring weights for time, cost and safety
 - **output.yaml** – cache duration and visualization options
+- **api_secrets.yaml** – API keys (ignored by git, create locally)
 
 See the files in the `config/` directory for examples.
 
@@ -184,7 +185,7 @@ The following packages need to be installed (see `requirements.txt`):
 ### User Documentation
 - [ ] Create comprehensive README.md
 - [ ] Add configuration examples
-- [ ] Document API key setup process
+- [x] Document API key setup process
 - [ ] Create troubleshooting guide
 
 ### Technical Documentation
@@ -196,7 +197,7 @@ The following packages need to be installed (see `requirements.txt`):
 ## Security and Privacy
 
 ### Security Tasks
-- [ ] Secure API key storage
+- [x] Secure API key storage
 - [ ] Validate all user inputs
 - [ ] Sanitize file paths
 - [ ] Add rate limiting protection
@@ -229,6 +230,7 @@ To get the Location Evaluator running:
 
 1. **Setup API Access**
    - [ ] Update `config/api.yaml`
+   - [ ] Create `config/api_secrets.yaml` with your FBI API key
 
 2. **Configure Analysis**
    - [ ] Set center_point in `config/analysis.yaml`

--- a/config/examples/api_secrets_example.yaml
+++ b/config/examples/api_secrets_example.yaml
@@ -1,0 +1,3 @@
+# Example API secrets configuration
+# Copy this file to config/api_secrets.yaml and set your actual keys.
+FBI_API_KEY: "YOUR_FBI_API_KEY"

--- a/tests/unit/test_api_secrets.py
+++ b/tests/unit/test_api_secrets.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from src.config_parser import ConfigParser
+
+
+def _create_minimal_config(path):
+    (path / 'analysis.yaml').write_text('analysis:\n  center_point: [0,0]\n  grid_size: 1\n  max_radius: 5\n')
+    dest_yaml = '''destinations:
+  work:
+    - address: "A"
+      name: "Office"
+      schedule:
+        - days: "Mon"
+          arrival_time: "09:00"
+          departure_time: "17:00"'''
+    (path / 'destinations.yaml').write_text(dest_yaml)
+    (path / 'transportation.yaml').write_text('transportation:\n  modes:\n    - driving\n')
+    (path / 'api.yaml').write_text('apis:\n  osrm:\n    base_url: http://localhost:5000\n    timeout: 30\n    requests_per_second: 10\n    cache: false\n    batch_size: 5\n  fbi_crime:\n    base_url: https://example.com/\n    timeout: 30\n')
+    (path / 'weights.yaml').write_text('weights:\n  travel_time: 0.5\n  travel_cost: 0.3\n  safety: 0.2\n')
+    (path / 'output.yaml').write_text('output:\n  output_format: json\n  cache_duration: 7\n')
+
+
+def test_api_secrets_file_sets_env(tmp_path, monkeypatch):
+    _create_minimal_config(tmp_path)
+    (tmp_path / 'api_secrets.yaml').write_text('FBI_API_KEY: TESTKEY')
+    monkeypatch.delenv('FBI_API_KEY', raising=False)
+    parser = ConfigParser()
+    cfg = parser.load_config(tmp_path)
+    parser.validate_config(cfg)
+    assert os.getenv('FBI_API_KEY') == 'TESTKEY'

--- a/tests/unit/test_crime_data.py
+++ b/tests/unit/test_crime_data.py
@@ -34,7 +34,7 @@ def test_get_crime_data_makes_request(monkeypatch):
 
     monkeypatch.setattr(crime_data.requests, 'get', fake_get)
 
-    data = crime_data.get_crime_data(40.0, -75.0, radius_miles=0.5)
+    data = crime_data.get_crime_data(40.0, -75.0, radius_miles=0.5, use_cache=False)
     assert called['url'].startswith('https://')
     assert data['incident_count'] == 3
     assert data['violent_crimes'] == 1


### PR DESCRIPTION
## Summary
- add optional `api_secrets.yaml` example for API keys
- ignore `config/api_secrets.yaml`
- load API secrets in `ConfigParser`
- update documentation and TODOs
- add test for secrets loading
- adjust cache test to avoid interference

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c9b194be88322adae24ad4a71a053