### PR TITLE
Fix duplicate schedule error

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -270,9 +270,13 @@ class LocationAnalyzer:
             monthly_map = schedules_df.assign(
                 weight=schedules_df['frequency'].map({'weekly': 52/12, 'monthly': 1.0})
             ).groupby('destination')['weight'].sum()
-            dest_meta = schedules_df[
-                ['destination', 'destination_name', 'category', 'departure_time']
-            ].drop_duplicates().set_index('destination')
+            dest_meta = (
+                schedules_df[
+                    ['destination', 'destination_name', 'category', 'departure_time']
+                ]
+                .drop_duplicates(subset=['destination'])
+                .set_index('destination')
+            )
 
         route_records = []
         for pid, dests in route_data.get('routes', {}).items():

--- a/tests/unit/test_duplicate_schedule.py
+++ b/tests/unit/test_duplicate_schedule.py
@@ -1,0 +1,59 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from src.analyzer import LocationAnalyzer
+
+
+def test_analyze_locations_with_duplicate_destinations():
+    cfg = {
+        'analysis': {
+            'grid_size': 0.1,
+            'max_radius': 0.1,
+            'center_point': [0.0, 0.0],
+        },
+        'destinations': {},
+        'transportation': {},
+        'weights': {},
+        'output': {},
+    }
+
+    analyzer = LocationAnalyzer(cfg)
+    analyzer._setup_analysis_grid()
+
+    analyzer.schedules = [
+        {
+            'destination': '123 Main St',
+            'destination_name': 'A',
+            'category': 'cat1',
+            'departure_time': '09:00',
+            'day': 'Mon',
+            'frequency': 'weekly',
+            'annual_occurrences': 52,
+        },
+        {
+            'destination': '123 Main St',
+            'destination_name': 'A2',
+            'category': 'cat2',
+            'departure_time': '10:00',
+            'day': 'Tue',
+            'frequency': 'weekly',
+            'annual_occurrences': 52,
+        },
+    ]
+
+    route_data = {
+        'routes': {
+            0: {
+                '123 Main St': {
+                    'status': 'OK',
+                    'duration_seconds': 600,
+                    'distance_miles': 1.0,
+                }
+            }
+        }
+    }
+
+    results = analyzer._analyze_locations(route_data)
+    assert results[0].travel_analysis.destinations
+


### PR DESCRIPTION
## Summary
- avoid unhashable Series errors by dropping duplicate destinations in `_analyze_locations`
- add unit test covering duplicate schedules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d13848fd083228640d0e18607ae0c