### PR TITLE
Improve OSRM caching using pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The following packages need to be installed (see `requirements.txt`):
 ### Optimization Tasks
 - [ ] Implement parallel API processing
 - [ ] Add memory usage monitoring
-- [ ] Optimize cache file formats
+ - [x] Optimize cache file formats
 - [x] Add OSRM client caching for route requests
  - [x] Add progress indicators
 - [x] Vectorize analysis calculations with pandas

--- a/tests/unit/test_osrm_cache.py
+++ b/tests/unit/test_osrm_cache.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from src.apis.cache import save_cached_osrm_route, get_cached_osrm_route
+
+
+def test_osrm_cache_roundtrip(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    route = {'distance_miles': 2.0, 'duration_seconds': 120, 'status': 'OK'}
+    save_cached_osrm_route(1.0, 2.0, 3.0, 4.0, route, cache_duration_days=1)
+    res = get_cached_osrm_route(1.0, 2.0, 3.0, 4.0)
+    assert res == route
+    os.chdir(cwd)
+
+
+def test_osrm_cache_expired(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    route = {'distance_miles': 1.0, 'duration_seconds': 60, 'status': 'OK'}
+    save_cached_osrm_route(5.0, 6.0, 7.0, 8.0, route, cache_duration_days=-1)
+    res = get_cached_osrm_route(5.0, 6.0, 7.0, 8.0)
+    assert res is None
+    os.chdir(cwd)


### PR DESCRIPTION
## Summary
- refactor OSRM caching to use a CSV file via pandas
- rewrite `route_batch` to operate on pandas DataFrames
- add tests for OSRM cache
- mark cache file format optimization as done in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2771f2fc83228a24be687e11d44c