### PR TITLE
Fix zero-distance routes due to missing coordinates

### DIFF
--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -34,7 +34,9 @@ def process_schedules(config: Dict[str, Any]) -> List[Dict[str, Any]]:
                             'departure_time': schedule_item['arrival_time'],
                             'day': day,
                             'frequency': 'weekly',
-                            'annual_occurrences': 52
+                            'annual_occurrences': 52,
+                            'lat': destination.get('lat'),
+                            'lon': destination.get('lon'),
                         })
                         
                 elif 'pattern' in schedule_item:
@@ -46,7 +48,9 @@ def process_schedules(config: Dict[str, Any]) -> List[Dict[str, Any]]:
                         'departure_time': schedule_item['arrival_time'],
                         'pattern': schedule_item['pattern'],
                         'frequency': 'monthly',
-                        'annual_occurrences': 12
+                        'annual_occurrences': 12,
+                        'lat': destination.get('lat'),
+                        'lon': destination.get('lon'),
                     })
     
     return schedules

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
-from src.core.scheduler import parse_days, calculate_monthly_pattern_dates
+from src.core.scheduler import parse_days, calculate_monthly_pattern_dates, process_schedules
 
 
 def test_parse_days_variants():
@@ -19,3 +19,23 @@ def test_monthly_pattern_dates_first_monday():
     assert len(dates) == 12
     assert dates[0] == datetime(2023, 1, 2)
     assert dates[1] == datetime(2023, 2, 6)
+
+
+def test_process_schedules_includes_coordinates():
+    cfg = {
+        'destinations': {
+            'work': [
+                {
+                    'address': '123 A St',
+                    'name': 'Office',
+                    'lat': 1.0,
+                    'lon': 2.0,
+                    'schedule': [
+                        {'days': 'Mon', 'arrival_time': '09:00', 'departure_time': '17:00'}
+                    ],
+                }
+            ]
+        }
+    }
+    schedules = process_schedules(cfg)
+    assert schedules and schedules[0]['lat'] == 1.0 and schedules[0]['lon'] == 2.0


### PR DESCRIPTION
## Summary
- propagate lat/lon into schedule items in `process_schedules`
- add a unit test covering coordinate propagation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d34b2f4b88322898428e3dc4983c0