### PR TITLE
Fix bounding box calculation for crime data

### DIFF
--- a/src/apis/crime_data.py
+++ b/src/apis/crime_data.py
@@ -17,6 +17,7 @@ If FBI API is unavailable:
 import os
 import requests
 import json
+import math
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from .cache import get_cached_crime_data, save_cached_crime_data
@@ -62,8 +63,6 @@ def get_crime_data(
     if use_cache and not force_refresh:
         cached = get_cached_crime_data(lat, lon, radius_miles)
         if cached is not None:
-            if cached.get('crime_data') is not None and cached.get('crime_data').get('crime_score') != 0.0:
-                print(cached.get('crime_data'))
             return cached
 
     # Convert to bounding box
@@ -126,7 +125,11 @@ def get_bounding_box(lat: float, lon: float, radius_miles: float) -> Dict[str, f
     # Longitude varies by latitude: 1 degree longitude ≈ 69 * cos(latitude) miles
     
     lat_offset = radius_miles / 69.0
-    lon_offset = radius_miles / (69.0 * abs(lat))
+    cos_lat = math.cos(math.radians(lat))
+    if cos_lat == 0:
+        lon_offset = 0
+    else:
+        lon_offset = radius_miles / (69.0 * cos_lat)
     
     return {
         'north': lat + lat_offset,

--- a/tests/unit/test_crime_data.py
+++ b/tests/unit/test_crime_data.py
@@ -124,3 +124,13 @@ def test_calculate_safety_score_uses_weights():
         weights={'violent': 4.0, 'property': 2.0, 'other': 1.0},
     )
     assert weighted > default
+
+
+def test_get_bounding_box_produces_reasonable_offsets():
+    bbox = crime_data.get_bounding_box(40.0, -75.0, 1.0)
+    assert bbox['north'] > 40.0
+    assert bbox['south'] < 40.0
+    assert bbox['east'] > -75.0
+    assert bbox['west'] < -75.0
+    assert bbox['east'] - bbox['west'] > 0
+    assert bbox['north'] - bbox['south'] > 0


### PR DESCRIPTION
## Summary
- avoid needless print and return cached values from `get_crime_data`
- correct longitude offset in `get_bounding_box`
- add unit test for bounding box helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8e50234c8322b2c1d486993a356e